### PR TITLE
Support alternative / multiple id's in a modbus network

### DIFF
--- a/epsolar_tracer/client.py
+++ b/epsolar_tracer/client.py
@@ -21,10 +21,10 @@ class EPsolarTracerClient:
     """ EPsolar Tracer client
     """
 
-    def __init__(self, unit: int=1, serialclient: ModbusClient=None, **kwargs):
+    def __init__(self, serialclient: ModbusClient=None, **kwargs):
         """ Initialize a serial client instance
         """
-        self.unit = unit
+        self.unit = kwargs.get('unit', 1)
         if serialclient is None:
             port = kwargs.get('port', '/dev/ttyXRUSB0')
             baudrate = kwargs.get('baudrate', 115200)


### PR DESCRIPTION
I did a small patch to be able to pull choose an alternative unit id, I have currently two epevers on a modbus-network, to poll each unit a separate unit-id needs to be supplied 