### PR TITLE
Fix bug with how keyword args are passed to ModbusSerialClient

### DIFF
--- a/epsolar_tracer/client.py
+++ b/epsolar_tracer/client.py
@@ -28,7 +28,7 @@ class EPsolarTracerClient:
         if serialclient is None:
             port = kwargs.get('port', '/dev/ttyXRUSB0')
             baudrate = kwargs.get('baudrate', 115200)
-            self.client = ModbusClient(method='rtu', port=port, baudrate=baudrate, kwargs=kwargs)
+            self.client = ModbusClient(method='rtu', port=port, baudrate=baudrate, **kwargs)
         else:
             self.client = serialclient
 


### PR DESCRIPTION
**Why?** The existing implementation results in kwargs being nested
within the kwargs variable of the ModbusSerialClient. e.g.

```
kwargs = {'kwargs': { ... }}
```

This means that arguments like `timeout` are not honored.