### PR TITLE
Fix broken ModbusSerialClient port/baudrate arg handling

### DIFF
--- a/epsolar_tracer/client.py
+++ b/epsolar_tracer/client.py
@@ -26,9 +26,13 @@ class EPsolarTracerClient:
         """
         self.unit = unit
         if serialclient is None:
-            port = kwargs.get('port', '/dev/ttyXRUSB0')
-            baudrate = kwargs.get('baudrate', 115200)
-            self.client = ModbusClient(method='rtu', port=port, baudrate=baudrate, **kwargs)
+            if not 'port' in kwargs:
+                kwargs['port'] = '/dev/ttyXRUSB0'
+
+            if not 'baudrate' in kwargs:
+                kwargs['baudrate'] = 115200
+
+            self.client = ModbusClient(method='rtu', **kwargs)
         else:
             self.client = serialclient
 


### PR DESCRIPTION
**Why?** My previous PR https://github.com/Salamek/epsolar-tracer/commit/78bb985a5bb5
fixed the handling of other keyword args like `timeout`, but broke the `port`/`baudrate`
args because those args were explicitly extracted from `kwargs` and passed
into `ModbusSerialClient`. Thus when either `port` or `baudrate` were present
in `kwargs`, they were duplicated in the arguments passed to
`ModbusSerialClient` which results in an exception.

To avoid that, this commit stops passing the explicit `port`/`baudrate`
args into `ModbusSerialClient` and opts to preserve the existing behavior of
having defaults for those values by writing the defaults into `kwargs`
iff they are not present there.

One could argue that it is a little unconventional to modify `kwargs`,
however it seems to be the most concise way to keep the code simple
while preserving the existing external interface of
`EPsolarTracerClient`. Ref: https://stackoverflow.com/a/45883925